### PR TITLE
Update github actions- 3 are failing

### DIFF
--- a/.github/workflows/update_cookbook_preview.yml
+++ b/.github/workflows/update_cookbook_preview.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Update Cookbook submodule preview
         run: |
-          git submodule update --init --remote --recursive
+          git submodule update --init --recursive --remote docs/the-fair-cookbook
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.github/workflows/update_specs_stable.yml
+++ b/.github/workflows/update_specs_stable.yml
@@ -8,11 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: merge specifications-and-documentation submodule to stable
-      run: |
-        # From https://github.com/actions/checkout/issues/116#issuecomment-583221947
-        git config --global url."https://github.com/".insteadOf "git@github.com:"
-        git submodule sync --recursive
-        git -c "http.extraheader=Authorization: basic ${{secrets.ALLTHEACTIONS}}" -c protocol.version=2 submodule update --init --force --recursive --remote docs/specifications-and-documentation
+        run: |
+          # From https://github.com/actions/checkout/issues/116#issuecomment-583221947
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule sync --recursive
+          git -c "http.extraheader=Authorization: basic ${{secrets.ALLTHEACTIONS}}" -c protocol.version=2 submodule update --init --force --recursive --remote docs/specifications-and-documentation
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.github/workflows/update_specs_stable.yml
+++ b/.github/workflows/update_specs_stable.yml
@@ -8,8 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: merge specifications-and-documentation submodule to stable
-        run: |
-          git -c "http.extraheader=Authorization: basic ${{secrets.ALLTHEACTIONS}}" submodule update --init --recursive --remote docs/specifications-and-documentation
+      run: |
+        # From https://github.com/actions/checkout/issues/116#issuecomment-583221947
+        git config --global url."https://github.com/".insteadOf "git@github.com:"
+        git submodule sync --recursive
+        git -c "http.extraheader=Authorization: basic ${{secrets.ALLTHEACTIONS}}" -c protocol.version=2 submodule update --init --force --recursive --remote docs/specifications-and-documentation
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:


### PR DESCRIPTION
of the 4 github actions that do the automatic checking of the-fair-cookbook and specifications-and-documentation 3 are failing. https://github.com/nih-cfde/published-documentation/blob/dev/.github/workflows/update_cookbook_stable.yml is the only one not. 

first commit changes the syntax of update_cookbook_preview to match update_cookbook_stable 

