### PR TITLE
update preview to stop failing and try to get checkout to work

### DIFF
--- a/.github/workflows/update_specs_preview.yml
+++ b/.github/workflows/update_specs_preview.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update spec and docs submodule preview
-        run: |
-          git -c "http.extraheader=Authorization: basic ${{secrets.ALLTHEACTIONS}}" submodule update --init --recursive --remote docs/specifications-and-documentation
+        with:
+          repository: nih-cfde/specifications-and-documentation
+          submodules: "recursive"
+          token: ${{ secrets.ALLTHEACTIONS }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "docs/specifications-and-documentation"]
 	path = docs/specifications-and-documentation
 	url = git@github.com:nih-cfde/specifications-and-documentation.git
+	branch = master


### PR DESCRIPTION
The last PR did make the stable action stop failing

but it didn't update the submodule.

This PR updates the preview action to match the new stable code so it stops failing and adds a branch specification to the gitmodule to try to force it to update correctly