### PR TITLE
previous fix didn't work

### DIFF
--- a/.github/workflows/update_specs_stable.yml
+++ b/.github/workflows/update_specs_stable.yml
@@ -7,10 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          repository: nih-cfde/specifications-and-documentation
-          submodules: "recursive"
-          token: ${{ secrets.ALLTHEACTIONS }}
+      - name: Checkout submodule
+        run: |
+          git config --file=.gitmodules submodule.lib/https://github.com/nih-cfde/specifications-and-documentation.git https://${{ ALLTHEACTIONS }}:${{ ALLTHEACTIONS }}@github.com/nih-cfde/specifications-and-documentation.git
+          git submodule sync
+          git submodule update --init --recursive
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:


### PR DESCRIPTION
I misunderstood the action docs. repository sets the base repo not the repo to access. so I was checking specifications-and-documentation against itself. that's why it wasn't getting the changes.

so that iteration fixed the auth, but by breaking functionality. back to trying to fix the auth a different way. 