### PR TITLE
Fix cookbook link and navbar

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,7 @@
+nav:
+- index.md
+- CFDE Glossary: CFDE-glossary.md
+- About the CFDE: about
+- C2M2 Documentation: c2m2
+- Submission Tool: cfde-submit
+- The FAIR Cookbook: the-fair-cookbook

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,4 @@ To facilitate this task, of the CFDE have developed and refined software tools. 
 - The [Crosscut Metadata Model](./c2m2/draft-C2M2_specification/README.md) (C2M2), a flexible standard for describing biomedical experimental data.
 - The [Datapackage Submission System](./cfde-submit/docs/index.md), how Common Fund metadata is submitted to the CFDE portal
      - For help with submissions you can also check the [wiki](https://github.com/nih-cfde/published-documentation/wiki) or search common errors in the [discussion board](https://github.com/nih-cfde/published-documentation/discussions)
-- The [FAIR cookbook](./the-fair-cookbook/content/intro.md) provides introductory materials about various aspects of FAIRness, including practical guides that show how to enhance digital objects by adhering them to community accepted standards.
+- The [FAIR cookbook](./the-fair-cookbook/intro.md) provides introductory materials about various aspects of FAIRness, including practical guides that show how to enhance digital objects by adhering them to community accepted standards.


### PR DESCRIPTION
2 changes:
- changed path to 1st pg of cookbook on docs home page
- added .pages to specify navbar names (otherwise, cookbook was showing up as repo name "the fair cookbook" instead of "The FAIR Cookbook")

these changes should link correctly to the updated cookbook once #211 is merged in.