### PR TITLE
Update .pages

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -3,6 +3,6 @@ nav:
 - About the CFDE: about
 - C2M2 Documentation: c2m2
 - CFDE Glossary: CFDE-glossary.md
-- Portal User Guide: about/portalguide.md
+- Portal User Guide: about/portalguide
 - Portal Submission Tool: cfde-submit
 - The FAIR Cookbook: the-fair-cookbook


### PR DESCRIPTION
link to portal user guide not working

needs to be 

https://docs.nih-cfde.org/en/latest/about/portalguide/ not https://docs.nih-cfde.org/en/latest/about/portalguide.md